### PR TITLE
fgds-mem: tidy fgds-mem.h

### DIFF
--- a/module/fgds-mem.c
+++ b/module/fgds-mem.c
@@ -17,7 +17,7 @@
 #include "nvfs-p2p.h"
 #include "config-host.h"
 
-static DEFINE_HASHTABLE(fgds_io_mbuffer_hash, FGDS_MAX_SHADOW_ALLOCS_ORDER);
+static DEFINE_HASHTABLE(fgds_io_mbuffer_hash, FGDS_IO_MBUFFER_HASH_BITS);
 static spinlock_t lock ____cacheline_aligned; 
 atomic_t base_index_cnt = ATOMIC_INIT(0);
 

--- a/module/fgds-mem.h
+++ b/module/fgds-mem.h
@@ -6,10 +6,8 @@
 #include <linux/file.h>
 #include "fgds.h"
 
-#define PAGE_SHIFT 12
 #define FGDS_MIN_BASE_INDEX ((unsigned long)1L<<32)
-#define FGDS_MAX_SHADOW_PAGES 4096
-#define FGDS_MAX_SHADOW_ALLOCS_ORDER 12
+#define FGDS_IO_MBUFFER_HASH_BITS 12  // fgds_io_mbuffer_hash 的哈希桶位数
 
 struct fgds_mmap_buffer { // 一次 mmap 映射区的内核侧「账本」，由 fgds_mmap 创建，由 ioctl MAP 时填充
     atomic_t ref; // 引用计数，为 0 时释放
@@ -19,22 +17,18 @@ struct fgds_mmap_buffer { // 一次 mmap 映射区的内核侧「账本」，由
     u64 dev_addr; // ioctl MAP 时绑定的 GPU 显存地址
     u64 dev_len; // ioctl MAP 时绑定的 GPU 显存长度
     unsigned long base_index; // 在 hash table 中的索引
-    unsigned long dev_id; // gpu id
+    unsigned long dev_id; // dev->idx,模块内 GPU 设备下标
     u64 *dev_page_addrs; // GPU 显存页的物理地址，调 nvidia 内核模块接口获取
     unsigned long dev_page_num; // GPU 显存页数
     unsigned long cpu_pages_per_gpu_page; // (dev_page_size / PAGE_SIZE) 一个 GPU 显存页对应多少个 CPU 页。目前是 64KB GPU 页 = 16 个 4KB CPU 页
     struct page **ppages; // 要插入进用户 VMA 的 CPU 内存页数组（映射到 GPU 显存页）
-    unsigned long host_page_num; // 对应的主机页数，等于 dev_page_num
+    unsigned long host_page_num; // 需要插入进 VMA 的 CPU 页数；dev_len < GPU_PAGE_SIZE 时按 4K 对齐取整，否则 = dev_page_num * cpu_pages_per_gpu_page
     struct vm_area_struct *vma; // 反向指向这块 mmap 的 VMA
     struct fgds_dev *dev;
-    bool remap; // 是否已完成页插入映射（成功 MAP 后置 true；由 remap_pfn_range 设置）
+    bool remap; // 是否已完成页插入映射（成功 MAP 后由 vm_insert_pages 置 true）
     struct p2p_vmap* map;
 };
 typedef struct fgds_mmap_buffer* fgds_mmap_buffer_t;
-
-
-typedef vm_fault_t fgds_vma_fault_t;
-
 
 int fgds_map_dev_addr_inner(fgds_mmap_buffer_t pbuffer, u64 devaddr, u64 dev_len);
 int fgds_map_dev_addr(fgds_ioctl_map_t *map_param, u64 devaddr, u64 dev_len, u64 cpuvaddr, u64 length);


### PR DESCRIPTION
Remove the redefinition of the kernel-provided PAGE_SHIFT, drop the unused FGDS_MAX_SHADOW_PAGES and fgds_vma_fault_t typedef, and rename FGDS_MAX_SHADOW_ALLOCS_ORDER to FGDS_IO_MBUFFER_HASH_BITS since it only serves as the hash-table bucket count (fgds-mem.c DEFINE_HASHTABLE). Correct stale field comments (host_page_num math, remap set by vm_insert_pages, dev_id meaning).